### PR TITLE
feat: added build badge from AzureDevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/leeroyashworthsa/DevOps-Presentation/_apis/build/status/leeroya.DevOps-Presentation?branchName=master)](https://dev.azure.com/leeroyashworthsa/DevOps-Presentation/_build/latest?definitionId=1&branchName=master)
+
 # DevOps Presentation
 
 This is a presentation repo for building and releasing software using containers.


### PR DESCRIPTION
This is to just add the Azure DevOps build badge to the main readme file to display in the github page